### PR TITLE
change: 議事録の英語名をchapterに統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 |  /edit-event | EditEventHandler |  POST  |イベント編集機能|
 |  /event-list  | EventListHandler |  GET  |イベント一覧取得|
 |  /event-detail | EventDetailHandler |  GET  |イベント詳細|
-|  /create-abstract | CreateAbstractHandler |  POST  |議事録作成|
-|  /edit-abstract | EditAbstractHandler |  POST  |議事録編集|
+|  /create-chapter | CreateChapterHandler |  POST  |議事録作成|
+|  /edit-chapter | EditChapterHandler |  POST  |議事録編集|
 
 
 ## LoginHandler

--- a/handler/handlers.go
+++ b/handler/handlers.go
@@ -37,10 +37,10 @@ func EventDetailHandler(w http.ResponseWriter, req *http.Request) {
 	io.WriteString(w, "EventDetailHandler\n")
 }
 
-func CreateAbstractHandler(w http.ResponseWriter, req *http.Request) {
-	io.WriteString(w, "CreateAbstractHandler\n")
+func CreateChapterHandler(w http.ResponseWriter, req *http.Request) {
+	io.WriteString(w, "CreateChapterHandler\n")
 }
 
-func EditAbstractHandler(w http.ResponseWriter, req *http.Request) {
-	io.WriteString(w, "EditAbstractHandler\n")
+func EditChapterHandler(w http.ResponseWriter, req *http.Request) {
+	io.WriteString(w, "EditChapterHandler\n")
 }

--- a/main.go
+++ b/main.go
@@ -33,8 +33,8 @@ func main() {
 	r.HandleFunc("/edit-event", handler.EditEventHandler).Methods(http.MethodPost)
 	r.HandleFunc("/event-list", handler.EventListHandler).Methods(http.MethodGet)
 	r.HandleFunc("/event-detail", handler.EventDetailHandler).Methods(http.MethodGet)
-	r.HandleFunc("/create-abstract", handler.CreateAbstractHandler).Methods(http.MethodPost)
-	r.HandleFunc("/edit-abstract", handler.EditAbstractHandler).Methods(http.MethodPost)
+	r.HandleFunc("/create-chapter", handler.CreateChapterHandler).Methods(http.MethodPost)
+	r.HandleFunc("/edit-chapter", handler.EditChapterHandler).Methods(http.MethodPost)
 
 	http.ListenAndServe(":8080", r)
 }


### PR DESCRIPTION
議事録の英語名がabstractとchapterで分かれている箇所があるために、chapterに統一する。