### PR TITLE
ユーザ認証周りのフロント・バックエンドのつなぎ込みを実装

### DIFF
--- a/handler/signup_handler.go
+++ b/handler/signup_handler.go
@@ -48,8 +48,8 @@ func SignUpHandler(w http.ResponseWriter, req *http.Request) {
 		fmt.Println("アカウントが作成されました")
 		return
 	}
-		resState.ResState = "failed"
-		resState.UserID = 0
-		json.NewEncoder(w).Encode(resState)
+	resState.ResState = "failed"
+	resState.UserID = 0
+	json.NewEncoder(w).Encode(resState)
 	fmt.Println("このメールアドレスは使用されています")
 }

--- a/handler/signup_handler.go
+++ b/handler/signup_handler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"io"
 	"database/sql"
 )
 
@@ -42,12 +41,15 @@ func SignUpHandler(w http.ResponseWriter, req *http.Request) {
 		}
 		//ストリームにしてhttpレスポンスに出力している。
 		id,_ := result.LastInsertId()
-		_, err = database.DB.Exec("INSERT INTO users (user_id VALUES (?)", id)
+		_, _ = database.DB.Exec("INSERT INTO users (user_id VALUES (?)", id)
 		resState.ResState = "success"
 		resState.UserID = id
 		json.NewEncoder(w).Encode(resState)
-		io.WriteString(w, "アカウントが作成されました\n")
+		fmt.Println("アカウントが作成されました")
 		return
 	}
+		resState.ResState = "failed"
+		resState.UserID = 0
+		json.NewEncoder(w).Encode(resState)
 	fmt.Println("このメールアドレスは使用されています")
 }

--- a/src/html/login.html
+++ b/src/html/login.html
@@ -1,35 +1,34 @@
 <!DOCTYPE html>
 <html>
-    <head>
-      <link rel="icon" type="image/png" href="../images/logo.png">
-        <meta charset="utf-8">
-        <title>輪読会</title>
-        <link rel="stylesheet" href="../css/account.css">
-    </head>  
+  <head>
+    <link rel="icon" type="image/png" href="../images/logo.png">
+    <meta charset="utf-8">
+    <title>輪読会</title>
+    <link rel="stylesheet" href="../css/account.css">
+  </head>
 
-    <body>
-      <div class="form-wrapper">
+  <body>
+    <div class="form-wrapper">
       <img src="../images/logo.png" class="title" >
-        <h1>サインイン</h1>
+      <h1>サインイン</h1>
       <form>
-      <div class="form-item">
-        <label for="email"></label>
-        <input type="email" name="email" required="required" placeholder="メールアドレス"></input>
+        <div class="form-item">
+          <label for="email"></label>
+          <input type="email" id="email" name="email" required="required" placeholder="メールアドレス" />
+        </div>
+        <div class="form-item">
+          <label for="password"></label>
+          <input type="password" id="password" name="password" required="required" placeholder="パスワード" />
+        </div>
+        <div class="button-panel1">
+          <input type="button" class="button" title="サインイン" value="サインイン" id="btn" onclick="postLogin()" />
+        </div>
+      </form>
+      <div class="form-footer">
+        <p><a href="sign-up.html">アカウントをつくる</a></p>
+        <p><a href="#">パスワードを忘れたら</a></p>
       </div>
-      <div class="form-item">
-        <label for="password"></label>
-        <input type="password" name="password" required="required" placeholder="パスワード"></input>
-      </div>
-      <div class="button-panel1">
-        <input type="submit" class="button" title="サインイン" value="サインイン" id="btn"></input>
-      </div>
-    </form>
-    <script src="../js/users/login.js"></script>
-  </body>
-    <div class="form-footer">
-      <p><a href="sign-up.html">アカウントをつくる</a></p>
-      <p><a href="#">パスワードを忘れたら</a></p>
+      <script src="../js/users/login.js"></script>
     </div>
-  </div>
+  </body>
 </html>
-

--- a/src/html/sign-up.html
+++ b/src/html/sign-up.html
@@ -1,39 +1,42 @@
 <!DOCTYPE html>
 <html>
-    <head>
-      <link rel="icon" type="image/png" href="../images/logo.png">
-        <meta charset="utf-8">
-        <title>輪読会</title>
-        <link rel="stylesheet" href="../css/account.css">
-    </head>  
+  <head>
+    <link rel="icon" type="image/png" href="../images/logo.png">
+    <meta charset="utf-8">
+    <title>輪読会</title>
+    <link rel="stylesheet" href="../css/account.css">
+  </head>
 
-    <body>
-      <div class="form-wrapper">
+  <body>
+    <div class="form-wrapper">
       <img src="../images/logo.png" class="title" >
-        <h1>新規会員登録</h1>
+      <h1>新規会員登録</h1>
       <form>
-      <div class="form-item">
-            <label for="username"></label> <!-- forとidを同じ値にする -->
-            <input type="username" id="username" required="required" placeholder="ユーザー名"></input>
-            <!-- requiredは入力必須の指定 -->
-      </div>
+        <div class="form-item">
+          <label for="username"></label> <!-- forとidを同じ値にする -->
+          <input type="username" id="username" required="required" placeholder="ユーザー名" />
+          <!-- requiredは入力必須の指定 -->
+        </div>
 
-      <div class="form-item">
-        <label for="email"></label>
-        <input type="email" id="email" required="required" placeholder="メールアドレス"></input>
-      </div>
+        <div class="form-item">
+          <label for="email"></label>
+          <input type="email" id="email" required="required" placeholder="メールアドレス" />
+        </div>
 
-      <div class="form-item">
-        <label for="password"></label> 
-        <input type="password" id="password" required="required" placeholder="パスワード"></input>
-      </div>
+        <div class="form-item">
+          <label for="password"></label>
+          <input type="password" id="password" required="required" placeholder="パスワード" />
+        </div>
 
-      <div class="button-panel2">
-        <input type="submit" class="button" title="登録" value="登録" id="btn"></input>
+        <div class="button-panel2">
+          <input type="button" class="button" title="登録" value="登録" id="btn" onclick="postSignUp()" />
+        </div>
+      </form>
+      <div class="form-footer">
+        <p><a href="login.html">ログインはこちら</a></p>
+        <p><a href="#">パスワードを忘れたら</a></p>
       </div>
-
-      <script src="../js/users/sign-up.js"></script>
-    </form>
+    </div>
+    <script src="../js/users/sign-up.js"></script>
   </body>
-  </div>
 </html>

--- a/src/js/users/login.js
+++ b/src/js/users/login.js
@@ -1,31 +1,29 @@
-function btn1(){    
-    // 入力フォームの内容を取得
-    const email = document.getElementById('email').value;
-    const password = document.getElementById('password').value;
-    // 入力内容を出力
-    console.log(email);
-    console.log(password);
+const postLogin = async () => {
+  // 入力フォームの内容を取得
+  const email = await document.getElementById('email').value;
+  const password = await document.getElementById('password').value;
 
-    const parameter = {
-        method:'POST',
-        mode:'no-cors',
-        headers:{
-            'Content-Type':'application/json'
-        },
-        body: JSON.stringify({
-            email: email,
-            password: password
-        })
-    };
-    fetch('http://localhost:8080/sign-up', parameter).then((response) => {
-        console.log(response);
+  // 入力内容を出力
+  console.log(email);
+  console.log(password);
+
+  const parameter = await {
+    method: 'POST',
+    cache: "no-cache",
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      email: email,
+      password: password
     })
-    .catch(err => {
-        console.error(err);
-    })
-    // console.log(r);
+  };
+
+  const response = await fetch("http://localhost:8080/login", parameter);
+  const res = await response.json();
+  console.log(res);
+
+  if (res.res_state == 'success') {
+    window.location.href = '../html/event-list.html';
+  };
 }
-
-const btn = document.getElementById('btn');
-
-btn.onclick = btn1;

--- a/src/js/users/sign-up.js
+++ b/src/js/users/sign-up.js
@@ -1,34 +1,32 @@
-function btn1(){    
-    // 入力フォームの内容を取得
-    const username = document.getElementById('username').value;
-    const email = document.getElementById('email').value;
-    const password = document.getElementById('password').value;
-    // 入力内容を出力
-    console.log(username);
-    console.log(email);
-    console.log(password);
+const postSignUp = async () => {
+  // 入力フォームの内容を取得
+  const username = await document.getElementById('username').value;
+  const email = await document.getElementById('email').value;
+  const password = await document.getElementById('password').value;
 
-    const parameter = {
-        method:'POST',
-        mode:'no-cors',
-        headers:{
-            'Content-Type':'application/json'
-        },
-        body: JSON.stringify({
-            user_name: username,
-            email: email,
-            password: password
-        })
-    };
-    fetch('http://localhost:8080/sign-up', parameter).then((response) => {
-        console.log(response);
+  // 入力内容を出力
+  console.log(username);
+  console.log(email);
+  console.log(password);
+
+  const parameter = await {
+    method:'POST',
+    cache: "no-cache",
+    headers:{
+        'Content-Type':'application/json'
+    },
+    body: JSON.stringify({
+        user_name: username,
+        email: email,
+        password: password
     })
-    .catch(err => {
-        console.error(err);
-    })
-    // console.log(r);
+  };
+
+  const response = await fetch("http://localhost:8080/sign-up", parameter);
+  const res = await response.json();
+  console.log(res);
+
+  if (res.res_state == 'success') {
+    window.location.href = '../html/event-list.html';
+  };
 }
-
-const btn = document.getElementById('btn');
-
-btn.onclick = btn1;


### PR DESCRIPTION
# 概要
- 新規会員登録のフォーム入力後、登録できたら議事録一覧画面に遷移
- ログインのフォーム入力後、ログインできたら議事録一覧画面に遷移

# その他
バリデーションや、同じメアドが使われてる時などのエラー時の挙動は実装してません(一連の処理が動くのを優先したため)