### PR TITLE
READMEのエンドポイントごとにリクエストとレスポンスの値を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,43 +29,208 @@
 |  /edit-chapter | EditChapterHandler |  POST  |議事録編集|
 
 
-## LoginHandler
+## /login
 ### Request(POST)
 | JSON Key | 型 | サイズ | 必須 | 値の説明 |
 |:-----------|:-----------|:-----------|:-----------|:-----------|
-| user_id | string | 10 | ○ | ユーザーの独自ID |
-| password | string | 20 | ○ | ユーザーのパスワード |
-
-### Response(POST)
-| JSON Key | 型 | サイズ | 必須 | 値の説明 |
-|:-----------|:-----------|:-----------|:-----------|:-----------|
-| user_id | string | 10 | ○ | ユーザーの独自ID |
-| login_flg | bool |  | ○ | ログイン成功or失敗 |
-
-## SignUpHandler
-### Request(POST)
-| JSON Key | 型 | サイズ | 必須 | 値の説明 |
-|:-----------|:-----------|:-----------|:-----------|:-----------|
-| user_id | string | 10 | ○ | ユーザーの独自ID |
-| user_name | string | 40 | ○ | ユーザーの名前 |
-| password | string | 20 | ○ | ユーザーのパスワード |
 | email | string | 254 | ○ | eメールアドレス |
+| password | string | 20 | ○ | ユーザーのパスワード |
 
-### Response(POST)
+### Response
+#### 成功の場合
 | JSON Key | 型 | サイズ | 必須 | 値の説明 |
 |:-----------|:-----------|:-----------|:-----------|:-----------|
-| login_flg | bool |  | ○ | 新規登録成功or失敗 |
+| res_state | string | 10 | ○ | 保存成功ステータス(success) |
+| user_id | string | 10 | ○ | ユーザーID |
 
-## CreateEventHandler
+#### 失敗の場合
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | 保存失敗ステータス(failed) |
+| user_id | string | 10 | ○ | 保存失敗したときは0 |
+
+## /sign-up
 ### Request(POST)
 | JSON Key | 型 | サイズ | 必須 | 値の説明 |
 |:-----------|:-----------|:-----------|:-----------|:-----------|
-| user_id | string | 10 | ○ | ユーザーの独自ID |
 | user_name | string | 40 | ○ | ユーザーの名前 |
-| password | string | 20 | ○ | ユーザーのパスワード |
 | email | string | 254 | ○ | eメールアドレス |
+| password | string | 20 | ○ | ユーザーのパスワード |
 
 ### Response(POST)
+#### 成功の場合
 | JSON Key | 型 | サイズ | 必須 | 値の説明 |
 |:-----------|:-----------|:-----------|:-----------|:-----------|
-| login_flg | bool |  | ○ | 新規登録成功or失敗 |
+| res_state | string | 10 | ○ | 保存成功ステータス(success) |
+| user_id | string | 10 | ○ | ユーザーID |
+
+#### 失敗の場合(同じEmailがDBにあるときなど)
+
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | 保存失敗ステータス(failed) |
+| user_id | string | 10 | ○ | 保存失敗したときは0 |
+
+## /create-event
+### Request(POST)
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| event_name | string | 40 | ○ | イベントの名前 |
+| book_name | string | 40 | ○ | 書籍名 |
+| member_list | string | 40 | ○ | 参加メンバー |
+
+### Response(POST)
+#### 成功の場合
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | 保存成功ステータス(success) |
+| event_id | int | 10 | ○ | イベントID |
+
+#### 失敗の場合(同じEmailがDBにあるときなど)
+
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | 保存失敗ステータス(failed) |
+| event_id | int | 10 | ○ | イベントID(保存失敗したときは0) |
+
+## /edit-event
+### Request(POST)
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| event_name | string | 40 | ○ | イベントの名前 |
+| book_name | string | 40 | ○ | 書籍名 |
+| member_list | string | 40 | ○ | 参加メンバー |
+
+### Response(POST)
+#### 成功の場合
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | 保存成功ステータス(success) |
+| event_id | int | 10 | ○ | イベントID |
+
+#### 失敗の場合(同じEmailがDBにあるときなど)
+
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | 保存失敗ステータス(failed) |
+| event_id | int | 10 | ○ | イベントID(保存失敗したときは0) |
+
+## /event-list
+ログインしているユーザが参加しているイベントを返す
+
+### Request(GET)
+なし
+
+### Response
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | ステータス |
+| event_id | int | 10 | ○ | イベントID |
+| book_name | string | 10 | ○ | 書籍名 |
+| member_count | string | 10 | ○ | 参加人数 |
+レスポンス例
+```
+{
+  "res_state": "success",
+  "events": [
+    {
+      "event_id": 1,
+      "book_name": "book1",
+      "member_count": 3,
+    },
+    {
+      "event_id": 2,
+      "book_name": "book2",
+      "member_count": 5,
+    },
+  ]
+}
+```
+
+## /create-chapter
+### Request(POST)
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| event_date | date | 40 | ○ | 開催日 |
+| venue | string | 254 | ○ | 開催場所 |
+| chapter_num | int | 20 | ○ | 章 |
+| content | int | 20 | ○ | 内容 |
+
+### Response(POST)
+#### 成功の場合
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | 保存成功ステータス(success) |
+| event_id | int | 10 | ○ | イベントID |
+
+#### 失敗の場合(同じEmailがDBにあるときなど)
+
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | 保存失敗ステータス(failed) |
+| event_id | int | 10 | ○ | イベントID(保存失敗した時は0) |
+
+
+## /chapter-list
+対象のイベントの議事録一覧ページの情報を返す
+
+### Request(GET)
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| event_id | int | 10 | ○ | イベントID |
+
+### Response
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | ステータス |
+| event_date | date | 40 | ○ | 開催日 |
+| venue | string | 254 | ○ | 開催場所 |
+| chapter_num | int | 20 | ○ | 章 |
+| content | int | 20 | ○ | 内容 |
+レスポンス例
+```
+{
+  "res_state": "success",
+  "event_id": 1,
+  "event_name": "リーダブルコード輪読会",
+  "chapters": [
+    {
+      "chapter_id": 1,
+      "event_date": "2022-11-02",
+      "venue": "オンライン",
+      "chapter_num": 1,
+      "content": "綺麗に書くことの重要性が書かれた章。~~~~~~~aaaaaaaaa",
+    },
+    {
+      "chapter_id": 2,
+      "event_date": "2022-11-03",
+      "venue": "スマプロのルーム",
+      "chapter_num": 2,
+      "content": "1行ごとの改善が大事ということを書いた章。~~~~~aaaaaaaa",
+    },
+  ]
+}
+```
+
+## /edit-chapter
+### Request(POST)
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| event_date | date | 40 | ○ | 開催日 |
+| venue | string | 254 | ○ | 開催場所 |
+| chapter_num | int | 20 | ○ | 章 |
+| content | int | 20 | ○ | 内容 |
+
+### Response(POST)
+#### 成功の場合
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | 保存成功ステータス(success) |
+| event_id | int | 10 | ○ | イベントID |
+
+#### 失敗の場合(同じEmailがDBにあるときなど)
+
+| JSON Key | 型 | サイズ | 必須 | 値の説明 |
+|:-----------|:-----------|:-----------|:-----------|:-----------|
+| res_state | string | 10 | ○ | 保存失敗ステータス(failed) |
+| event_id | int | 10 | ○ | イベントID(保存失敗した時は0) |


### PR DESCRIPTION
# 概要
バックエンドが受け取る値と返す値が不明で開発が進まなかったため、READMEを更新しました。

# レビューしてほしいところ
- ページごとにフロントエンド側が欲しい値をバックエンド側がレスポンスできてるかを「イベント一覧ページ」と「議事録一覧ページ」を主に確認お願いしたいです。