### PR TITLE
議事録作成機能を実装(バックエンド)

### DIFF
--- a/docker-entrypoint-initdb.d/schema.sql
+++ b/docker-entrypoint-initdb.d/schema.sql
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS chapters (
   chapter_num     INTEGER UNSIGNED NOT NULL,
   venue           VARCHAR(100) NOT NULL,
   event_id        INTEGER UNSIGNED NOT NULL,
-  event_date      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  event_date      DATE NOT NULL DEFAULT (CURRENT_DATE),
   content         TEXT     NOT NULL DEFAULT '',
   last_updater_id INTEGER UNSIGNED NOT NULL,
   created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/docker-entrypoint-initdb.d/schema.sql
+++ b/docker-entrypoint-initdb.d/schema.sql
@@ -1,3 +1,7 @@
+DROP DATABASE techread;
+CREATE DATABASE techread;
+USE techread;
+
 CREATE TABLE IF NOT EXISTS users (
   user_id       INTEGER UNSIGNED PRIMARY KEY AUTO_INCREMENT,
   user_name     VARCHAR(40)     NOT NULL,

--- a/docker-entrypoint-initdb.d/seed.sql
+++ b/docker-entrypoint-initdb.d/seed.sql
@@ -13,7 +13,7 @@ INSERT INTO events (
 INSERT INTO chapters (
   chapter_num, venue, event_id, event_date, content, last_updater_id, created_at, updated_at
 ) VALUES (
-  1, 'オンライン', 1, now(), '理解しやすいコード', 1, now(), now()
+  1, 'オンライン', 1, date(now()), '理解しやすいコード', 1, now(), now()
 );
 
 INSERT INTO comments (

--- a/docker-entrypoint-initdb.d/seed.sql
+++ b/docker-entrypoint-initdb.d/seed.sql
@@ -1,3 +1,6 @@
+CREATE DATABASE techread;
+USE techread;
+
 INSERT INTO users (
   user_name, email, password, created_at, updated_at
 ) VALUES (

--- a/handler/create_chapter_handler.go
+++ b/handler/create_chapter_handler.go
@@ -1,10 +1,61 @@
 package handler
 
 import (
-	"io"
+	"TechRead/database"
+	"TechRead/model"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"time"
 )
 
+type ReqChapter struct {
+	ChapterNum    int       `db:"chapter_num" form:"chapter_num" json:"chapter_num"`
+	Venue         string    `db:"venue" form:"venue" json:"venue"`
+	EventID       int       `db:"event_id" form:"event_id" json:"event_id"`
+	EventDate     time.Time `db:"event_date" form:"event_date" json:"event_date"`
+	Content       string       `db:"content" form:"content" json:"content"`
+}
+
 func CreateChapterHandler(w http.ResponseWriter, req *http.Request) {
-	io.WriteString(w, "CreateChapterHandler\n")
+	// リクエストを構造体に入れる
+	var reqChapter ReqChapter
+	if err := json.NewDecoder(req.Body).Decode(&reqChapter); err != nil {
+		fmt.Println(err)
+
+		var resState model.ResInfo
+		ResFail(resState)
+		json.NewEncoder(w).Encode(resState)
+		return
+	}
+
+	// TODO: フロントエンド側でcookieを入れる処理ができたら、cookieの値を読み取る処理に変更する
+	user_id := 1
+
+	// クエリ文を定義
+	const sqlStr = `
+		INSERT into chapters (chapter_num, venue, event_id, event_date, content, last_updater_id, created_at, updated_at) value
+		(?, ?, ?, ?, ?, ?, now(), now());
+	`
+
+	// dbに入れる処理
+	result, err := database.DB.Exec(sqlStr, reqChapter.ChapterNum, reqChapter.Venue, reqChapter.EventID, reqChapter.EventDate, reqChapter.Content, user_id)
+	if err != nil {
+		fmt.Println(err)
+
+		var resState model.ResInfo
+		ResFail(resState)
+		json.NewEncoder(w).Encode(resState)
+		return
+	}
+
+	// 保存したchapter_idを取得
+	chapterId, _ := result.LastInsertId()
+	fmt.Println(chapterId)
+
+	// 成功のレスポンスを返す
+	var resSuccess model.ResCreateChapter
+	resSuccess.ResState = "success"
+	resSuccess.ChapterID = chapterId
+	json.NewEncoder(w).Encode(resSuccess)
 }

--- a/model/chapter.go
+++ b/model/chapter.go
@@ -8,7 +8,7 @@ type Chapter struct {
 	Venue         string    `db:"venue" form:"venue" json:"venue"`
 	EventID       int       `db:"event_id" form:"event_id" json:"event_id"`
 	EventDate     time.Time `db:"event_date" form:"event_date" json:"event_date"`
-	Content       int       `db:"content" form:"content" json:"content"`
+	Content       string    `db:"content" form:"content" json:"content"`
 	LastUpdaterID int       `db:"last_updater_id" form:"last_updater_id" json:"last_updater_id"`
 	CreatedAt     time.Time `db:"created_at" form:"created_at" json:"created_at"`
 	UpdatedAt     time.Time `db:"updated_at" form:"updated_at" json:"updated_at"`

--- a/model/response.go
+++ b/model/response.go
@@ -4,3 +4,8 @@ type ResInfo struct {
 	ResState  string   `db:"res_state" form:"res_state" json:"res_state"`
 	UserID    int64      `db:"user_id" form:"user_id" json:"user_id"`
 }
+
+type ResCreateChapter struct {
+	ResState  string   `db:"res_state" form:"res_state" json:"res_state"`
+	ChapterID int64    `db:"chapter_id" form:"res_state" json:"chapter_id"`
+}


### PR DESCRIPTION
# 関連Issue
Resolve https://github.com/nihei-shunsuke/TechRead/issues/11

# 概要
- 議事録作成機能のCreateChapterを実装
- sqlファイルでデータベースの指定する文を追加
- 構造体やmysqlの型を適宜修正

# まだやってないこと(draftの理由)
cookieからuser_idを取り出す処理が実装できてないため。高木さんにフロントエンド側でCookieにuser_idを入れる処理をしてもらったら実装します。