### PR TITLE
フロントエンド側の起動方法をREADMEに追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@
 - `docker exec -it db-for-techread bash`
 - `mysql -u ユーザー名 -p`
 
-
-
+## API設計
 |  エンドポイント  |ハンドラ|  メソッド  | 説明 |
 | ---- | ---- |---- | ---- |
 |  /login | LoginHandler |  POST  |ログイン機能|
@@ -38,7 +37,6 @@
 ### Cookieについて
 - user_id: ログインしてるユーザID
 /login, /sign-upのレスポンスで来たuser_idをフロントエンド側でCookieに入れて、リクエストの度に送る。
-
 
 ## /login
 ### Request(POST)

--- a/README.md
+++ b/README.md
@@ -4,15 +4,22 @@
 - gorilla: Routing, Middleware,Session
 
 ## 起動方法
-### 初回 or Dockerfileに変更があった場合
+### フロントエンド側
+- Cookieに関わる処理が必要な場合、localhostを立ち上げる。Cookieを扱うには、サーバを立てないとできないらしい。
+- 方法はなんでもいいが、手軽なのはVSCodeの[Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer)という拡張機能。
+- ステータスバーのGo Liveボタンを押すと勝手にlocalhostが立ち上がります。
+
+### サーバーサイド側
+#### 初回 or Dockerfileに変更があった場合
 - `docker-compose up --build`
-### 2回目以降
+#### 2回目以降
 - `docker-compose up`
-### DBの初期化をするときは
+#### DBの初期化をするときは
 - `docker-compose down --volume`
-### DockerのDBにアクセスするときは
+#### DockerのDBにアクセスするときは
 - `docker exec -it db-for-techread bash`
 - `mysql -u ユーザー名 -p`
+
 
 
 |  エンドポイント  |ハンドラ|  メソッド  | 説明 |


### PR DESCRIPTION
# 概要
フロントエンド側の起動方法をREADMEに追記
# 背景
Cookieを扱う場合、HTMLはサーバを立ち上げないといけないため